### PR TITLE
Adding/removing services happens with accessors now

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,16 @@ all: quark
 quark: .ALWAYS
 	quark install --python quark/discovery-2.0.0.q quark/intro.q
 
-docker:
+discoball:
 	./gradlew clean build :discovery-web:buildDockerImage
 
-discoball:
+discostart:
 	docker run --name disco -p 52689:52689 \
 		-v $$(pwd)/discovery-web/config:/opt/discovery/config datawire/discovery:2.0.0
+
+discostop:
+	docker stop disco
+	docker rm disco
 
 clobber:
 	-find . -name '*.qc' -print0 | xargs -0 rm -f

--- a/examples/python/server
+++ b/examples/python/server
@@ -14,6 +14,8 @@
 # need to get the end-to-end scenario working so we can identify any
 # sleeping dragons.
 
+import sys
+
 import logging
 logging.basicConfig(level=logging.DEBUG)
 
@@ -25,11 +27,15 @@ def hello():
     return "Hello World!"
 
 if __name__ == "__main__":
+    port_num = 5000
+
+    if len(sys.argv) > 1:
+        port_num = int(sys.argv[1])
 
     # Start discovery related changes.
     from util import Platform, Datawire
     host = Platform.getRoutableHost()
-    port = Platform.getRoutablePort(5000)
+    port = Platform.getRoutablePort(port_num)
 
     from discovery import Discovery, Node
     disco = Discovery().connect().withToken(Datawire.getToken()).start()

--- a/quark/discovery-2.0.0.q
+++ b/quark/discovery-2.0.0.q
@@ -286,6 +286,7 @@ namespace discovery {
 
     @doc("Register info about a service node with the discovery service. You must")
     @doc("usually start the uplink before this will do much; see start().")
+    Discovery register(Node node) {
       self._lock();
 
       String service = node.service;
@@ -298,6 +299,7 @@ namespace discovery {
       client.register(node);
 
       self._release();
+      return self;
     }
 
     @doc("Resolve a service name into an available service node. You must")

--- a/quark/discovery-2.0.0.q
+++ b/quark/discovery-2.0.0.q
@@ -1,4 +1,4 @@
-quark 0.7;
+quark 0.7.6;
 
 package datawire_discovery 2.0.0;
 
@@ -54,7 +54,6 @@ import util.internal;
 
 /*
   TODO:
-    - rename Cluster to something reasonable, e.g. ServiceInfo
     - disco.lookup -> Cluster (renamed)
     - disco.resolve -> is convenience for disco.lookup("<service>").choose()
     - disco.register -> Cluster (renamed), use to communicate error info on registry.
@@ -69,6 +68,8 @@ namespace discovery {
     List<Node> nodes = [];
     int idx = 0;
 
+    @doc("Choose a node from the cluster to talk to. At present this is a simple")
+    @doc("round robin.")
     Node choose() {
       if (nodes.size() > 0) {
         int choice = idx % nodes.size();
@@ -80,6 +81,9 @@ namespace discovery {
       }
     }
 
+    @doc("Add a node to the cluster (or, if it's already present in the cluster,")
+    @doc("update its properties). At present this involves a linear search, so, uh,")
+    @doc("adding ten million nodes is probably not a great idea.")
     void add(Node node) {
       int idx = 0;
 
@@ -97,6 +101,7 @@ namespace discovery {
       nodes.add(node);
     }
 
+    // XXX: toString() is a disaster for large clusters.
     String toString() {
       String result = "Cluster(";
 
@@ -128,6 +133,7 @@ namespace discovery {
     @doc("Additional metadata associated with this service instance.")
     Map<String,Object> properties;
 
+    @doc("Copy properties from some other Node to this one, and finish this Node.")
     void update(Node node) {
       service = node.service;
       version = node.version;
@@ -179,19 +185,19 @@ namespace discovery {
 
     static Logger logger = new Logger("discovery");
 
-    // Nodes we advertise to the disco service.
-    Map<String,Cluster> registered = new Map<String,Cluster>();
+    // Clusters we advertise to the disco service.
+    Map<String, Cluster> registered = new Map<String, Cluster>();
 
-    // Nodes the disco says are available, as well as nodes for
+    // Clusters the disco says are available, as well as clusters for
     // which we are awaiting resolution.
-    Map<String,Cluster> services = new Map<String,Cluster>();
+    Map<String, Cluster> services = new Map<String, Cluster>();
 
     bool started = false;
     Lock mutex = new Lock();
     DiscoClient client;
 
     @doc("Construct a Discovery object. You must connect the object to a")
-    @doc("discovery server before you can do anything; see connect() and")
+    @doc("discovery server before you can do anything else; see connect() and")
     @doc("connectTo()")
     Discovery() {
       logger.info("hello");
@@ -278,8 +284,8 @@ namespace discovery {
       return self;
     }
 
-    @doc("Register info about a service node with the discovery service.")
-    void register(Node node) {
+    @doc("Register info about a service node with the discovery service. You must")
+    @doc("usually start the uplink before this will do much; see start().")
       self._lock();
 
       String service = node.service;
@@ -294,7 +300,8 @@ namespace discovery {
       self._release();
     }
 
-    @doc("Resolve a service name into an available service node.")
+    @doc("Resolve a service name into an available service node. You must")
+    @doc("usually start the uplink before this will do much; see start().")
     Node resolve(String service) {
       Node result;
       self._lock();

--- a/quark/discovery_protocol.q
+++ b/quark/discovery_protocol.q
@@ -82,14 +82,8 @@ namespace discovery {
         // Stick the node in the available set.
 
         Node node = active.node;
-        String service = node.service;
 
-        if (!disco.services.contains(service)) {
-          disco.services[service] = new Cluster();
-        }
-
-        Cluster cluster = disco.services[service];
-        cluster.add(node);
+        disco.active(node);
       }
 
       void onExpire(Expire expire) {
@@ -99,14 +93,8 @@ namespace discovery {
         // continually updated until they expire...
 
         Node node = expire.node;
-        String service = node.service;
 
-        if (disco.services.contains(service)) {
-          // XXX: no way to remove from List or Map
-          // ...
-        }
-
-        // ...
+        disco.expire(node);
       }
 
       void onClear(Clear reset) {
@@ -242,9 +230,9 @@ namespace discovery {
       void onWSMessage(WebSocket socket, String message) {
         // Decode and dispatch incoming messages.
         DiscoveryEvent event = DiscoveryEvent.decode(message);
-        disco.mutex.acquire();
+        // disco.mutex.acquire();
         event.dispatch(self);
-        disco.mutex.release();
+        // disco.mutex.release();
       }
 
       void onWSBinary(WebSocket socket, Buffer message) { /* unused */ }


### PR DESCRIPTION
`discovery_protocol` no longer gets to reach into the `Discovery` object directly; it has to go through accessor functions to modify anything. This for ease in hooking from the UI.

This implies that `discovery_protocol` also no longer gets to directly mess with the `Discovery` object's lock.