### PR TITLE
Support the multitenant discoball

### DIFF
--- a/quark/discovery-2.0.0.q
+++ b/quark/discovery-2.0.0.q
@@ -204,7 +204,6 @@ namespace discovery {
   class Discovery {
     String url;
     String token;
-    bool gateway = false;
 
     static Logger logger = new Logger("discovery");
 

--- a/quark/discovery-2.0.0.q
+++ b/quark/discovery-2.0.0.q
@@ -263,7 +263,7 @@ namespace discovery {
 
     @doc("Connect to the default discovery server. If DATAWIRE_DISCOVERY_URL")
     @doc("is in the environment, it specifies the default; if not, we'll talk to")
-    @doc("disco.datawire.io.")
+    @doc("wss://discovery-beta.datawire.io/")
     Discovery connect() {
       EnvironmentVariable ddu = EnvironmentVariable("DATAWIRE_DISCOVERY_URL");
       String url = ddu.orElseGet("wss://discovery-beta.datawire.io/");

--- a/quark/discovery_protocol.q
+++ b/quark/discovery_protocol.q
@@ -137,73 +137,17 @@ namespace discovery {
           }
         }
         else {
-          if (!authenticating) {
-            authRequest();
-            authenticating = true;
-          }
-          else {
-            // WTF is this for? presumably if we're authenticating already,
-            // we shouldn't try to open a new connection.
-            open(disco.url);
-          }
+          open(disco.url);
         }
-      }
-
-      void authRequest() {
-        String url = disco.url;
-
-        if (disco.token != null) {
-          url = url + "/?token=" + token;
-        }
-
-        log.info("authenticating via " + url);
-
-        HTTPRequest request = new HTTPRequest(url);
-
-        Context.runtime().request(request, self);
-      }
-
-      void onHTTPInit(HTTPRequest request) { /* unused */ }
-
-      void onHTTPResponse(HTTPRequest request, HTTPResponse response) {
-        if (response.getCode() == 200) {
-          String url = response.getBody();
-          open(url);
-        }
-        else {
-          log.error(request.getUrl() + ": " + response.getBody());
-          scheduleReconnect();
-        }
-      }
-
-      void onHTTPError(HTTPRequest request, String message) {
-        // Any non-transient errors should be reported back to the
-        // user via any Nodes they have requested.
-        log.error(request.getUrl() + ": " + message);
-        scheduleReconnect();
-      }
-
-      void onHTTPFinal(HTTPRequest request) {
-        authenticating = false;
-      }
-
-      void onWSInit(WebSocket socket) { /* unused */ }
-
-      void onWSConnected(WebSocket socket) {
-        // Whenever we (re)connect, notify the server of any
-        // nodes we have registered.
-        log.info("connected to " + disco.url);
-
-        reconnectDelay = firstDelay;
-        sock = socket;
-
-        sock.send(new Open().encode());
-
-        heartbeat();
       }
 
       void open(String url) {
+        if (disco.token != null) {
+          url = url + "/?token=" + disco.token;
+        }
+
         log.info("opening " + url);
+
         Context.runtime().open(url, self);
       }
 
@@ -227,6 +171,21 @@ namespace discovery {
 
         lastHeartbeat = now();
         schedule(ttl/2.0);
+      }
+
+      void onWSInit(WebSocket socket) {/* unused */ }
+
+      void onWSConnected(WebSocket socket) {
+        // Whenever we (re)connect, notify the server of any
+        // nodes we have registered.
+        log.info("connected to " + disco.url);
+
+        reconnectDelay = firstDelay;
+        sock = socket;
+
+        sock.send(new Open().encode());
+
+        heartbeat();
       }
 
       void onWSMessage(WebSocket socket, String message) {

--- a/quark/discovery_protocol.q
+++ b/quark/discovery_protocol.q
@@ -138,27 +138,29 @@ namespace discovery {
         }
         else {
           if (!authenticating) {
-            if (disco.gateway) {
-              authRequest();
-              authenticating = true;
-            }
-            else {
-              open(disco.url);
-            }
+            authRequest();
+            authenticating = true;
+          }
+          else {
+            // WTF is this for? presumably if we're authenticating already,
+            // we shouldn't try to open a new connection.
+            open(disco.url);
           }
         }
       }
 
       void authRequest() {
-        HTTPRequest request = new HTTPRequest(disco.url + "/v2/connect");
-        request.setMethod("POST");
+        String url = disco.url;
 
         if (disco.token != null) {
-          request.setHeader("Authorization", "Bearer " + disco.token);
+          url = url + "/?token=" + token;
         }
 
+        log.info("authenticating via " + url);
+
+        HTTPRequest request = new HTTPRequest(url);
+
         Context.runtime().request(request, self);
-        log.info("gateway request " + request.getUrl());
       }
 
       void onHTTPInit(HTTPRequest request) { /* unused */ }
@@ -190,7 +192,7 @@ namespace discovery {
       void onWSConnected(WebSocket socket) {
         // Whenever we (re)connect, notify the server of any
         // nodes we have registered.
-        log.info("connectd to " + disco.url);
+        log.info("connected to " + disco.url);
 
         reconnectDelay = firstDelay;
         sock = socket;


### PR DESCRIPTION
- Update docs to reflect the reality of using `wss://discovery-beta.datawire.io` by default
- Kill the `gateway` concept, and _always_ go straight to `wss` endpoint, reflecting the discovery server design change from @rhs and @plombardi89 
- Append the token to the `wss` URL.
